### PR TITLE
FDN-4694 Remove Travis CI reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # aws-credentials-broker
 
-[![Build Status](https://app.travis-ci.com/flowcommerce/aws-credentials-broker.svg?token=ehYmhiZsnqWFWAoybfVc&branch=main)](https://app.travis-ci.com/flowcommerce/aws-credentials-broker)
-
 AWS Credentials Broker - Grants temporary AWS credentials for Google federated users
 
 This app when deployed in your AWS account can grant STS credentials to Google SAML federated users for use in the AWS CLI.


### PR DESCRIPTION
## Summary
- Remove Travis CI build status badges from README
- Remove any other Travis CI references (config files, scripts, code comments)

Travis CI is no longer in use.

Resolve [FDN-4694]

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[FDN-4694]: https://flowio.atlassian.net/browse/FDN-4694?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed Travis CI build status badge from README

<!-- end of auto-generated comment: release notes by coderabbit.ai -->