### PR TITLE
FDN-4681: Use Go 1.15 to build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the Go App
-FROM golang:1.24 AS go-builder
+FROM golang:1.25 AS go-builder
 
 COPY . /usr/src/aws-credentials-broker
 WORKDIR /usr/src/aws-credentials-broker
@@ -23,7 +23,7 @@ RUN apk add --no-cache --virtual .gyp \
 
 # Put it all together for a runtime app
 # The binary is at /usr/bin/aws-credentials-broker and the runtime data is at /var, per FHS.
-FROM golang:1.24
+FROM golang:1.25
 
 COPY --from=go-builder /usr/bin/aws-credentials-broker /usr/bin/aws-credentials-broker
 COPY --from=fe-builder /usr/src/aws-credentials-broker/templates /var/lib/aws-credentials-broker/templates


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Go runtime version to 1.25

<!-- end of auto-generated comment: release notes by coderabbit.ai -->