### PR TITLE
FDN-4741: Wire us-east-2 failover for aws-credentials-broker

### DIFF
--- a/deploy/aws-credentials-broker/app.yaml
+++ b/deploy/aws-credentials-broker/app.yaml
@@ -53,6 +53,8 @@ spec:
       parameters:
       - name: deployments.live.version
         value: "Jenkins_will_update_the_version"
+      - name: region
+        value: "Jenkins_will_update_the_region"
       valueFiles:
       - $values/deploy/aws-credentials-broker/values.yaml
   project: production

--- a/deploy/aws-credentials-broker/templates/deployment.yaml
+++ b/deploy/aws-credentials-broker/templates/deployment.yaml
@@ -1,5 +1,7 @@
 {{- $fullName := include "deploy.fullname" . -}}
+{{- $region := .Values.region | default "us-east-1" -}}
 {{- range $stage, $deployment := index .Values "deployments" }}
+{{- $regionDeployment := required (printf "regions.%s.deployment.%s is required" $region $stage) (dig $region "deployment" $stage "" $.Values.regions) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -53,16 +55,6 @@ spec:
                 secretKeyRef:
                   name: aws-credentials-broker
                   key: hosted_domain
-            - name: ALLOWED_ORIGIN
-              valueFrom:
-                secretKeyRef:
-                  name: aws-credentials-broker
-                  key: allowed_origin
-            - name: GOOGLE_CLIENT_REDIRECT
-              valueFrom:
-                secretKeyRef:
-                  name: aws-credentials-broker
-                  key: google_client_redirect
             - name: GOOGLE_CLIENT_ID
               valueFrom:
                 secretKeyRef:
@@ -126,6 +118,7 @@ spec:
               value: 'unix:///var/run/datadog/dsd.socket'
             - name: DD_SERVICE_MAPPING
               value: postgresql:{{ $.Chart.Name }}-postgresql,java-aws-sdk:{{ $.Chart.Name }}-aws-sdk"
+{{ toYaml (required (printf "regions.%s.deployment.%s.env is required" $region $stage) $regionDeployment.env) | indent 12 }}
           args: ["production"]
           ports:
             - name: http

--- a/deploy/aws-credentials-broker/templates/ingress.yaml
+++ b/deploy/aws-credentials-broker/templates/ingress.yaml
@@ -1,6 +1,8 @@
 {{- $fullName := include "deploy.fullname" . -}}
-{{- if .Values.ingress.enabled -}}
-{{- range $gateway := .Values.ingress.gateways }}
+{{- $region := .Values.region | default "us-east-1" -}}
+{{- $ingress := required (printf "regions.%s.ingress is required" $region) (dig $region "ingress" "" .Values.regions) -}}
+{{- if $ingress.enabled -}}
+{{- range $gateway := $ingress.gateways }}
 apiVersion: networking.istio.io/v1alpha3
 kind: Gateway
 metadata:
@@ -16,7 +18,7 @@ metadata:
     external-dns.alpha.kubernetes.io/ttl: "120"
 spec:
   selector:
-    istio: {{ $.Values.ingress.istioSelector }}
+    istio: {{ $ingress.istioSelector }}
   servers:
     - port:
         number: 80

--- a/deploy/aws-credentials-broker/templates/istio.yaml
+++ b/deploy/aws-credentials-broker/templates/istio.yaml
@@ -1,5 +1,7 @@
 {{- $fullName := include "deploy.fullname" . -}}
-{{- range $key, $service := index .Values "services" }}
+{{- $region := .Values.region | default "us-east-1" -}}
+{{- $services := required (printf "regions.%s.services is required" $region) (dig $region "services" "" .Values.regions) -}}
+{{- range $key, $service := $services }}
 apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
 metadata:

--- a/deploy/aws-credentials-broker/values.yaml
+++ b/deploy/aws-credentials-broker/values.yaml
@@ -26,27 +26,8 @@ tolerations:
 topologySpreadConstraints:
   schedule: "DoNotSchedule"
 
-ingress:
-  enabled: true
-  istioSelector: ingressgateway-flow-io
-  gateways:
-    - key: flow-io
-      tld: flow.io
-      hosts:
-        - aws-credentials-broker.flow.io
-
-services:
-  live:
-    stages:
-      - deployment: live
-        weight: 100
-    hosts:
-      - aws-credentials-broker
-      - aws-credentials-broker.flow.io
-    gateways:
-      - mesh
-      - aws-credentials-broker-flow-io
-
+# Non-region-specific deployment fields. Region-specific values (env) live
+# under regions.<region>.deployment.<stage>.
 deployments:
   live:
     minReplicas: 2
@@ -59,5 +40,57 @@ deployments:
     serviceAccountIamRole: "arn:aws:iam::479720515435:role/flow-prod-eks-production-role"
 
 regions:
-  us-east-1: {}
-  us-east-2: {}
+  us-east-1:
+    deployment:
+      live:
+        env:
+          - name: ALLOWED_ORIGIN
+            value: "https://aws-credentials-broker.flow.io"
+          - name: GOOGLE_CLIENT_REDIRECT
+            value: "https://aws-credentials-broker.flow.io/oauth/google/callback"
+    ingress:
+      enabled: true
+      istioSelector: ingressgateway-flow-io
+      gateways:
+        - key: flow-io
+          tld: flow.io
+          hosts:
+            - aws-credentials-broker.flow.io
+    services:
+      live:
+        stages:
+          - deployment: live
+            weight: 100
+        hosts:
+          - aws-credentials-broker
+          - aws-credentials-broker.flow.io
+        gateways:
+          - mesh
+          - aws-credentials-broker-flow-io
+  us-east-2:
+    deployment:
+      live:
+        env:
+          - name: ALLOWED_ORIGIN
+            value: "https://aws-credentials-broker.us-east-2.flow.io"
+          - name: GOOGLE_CLIENT_REDIRECT
+            value: "https://aws-credentials-broker.us-east-2.flow.io/oauth/google/callback"
+    ingress:
+      enabled: true
+      istioSelector: ingressgateway-flow-io
+      gateways:
+        - key: flow-io
+          tld: flow.io
+          hosts:
+            - aws-credentials-broker.us-east-2.flow.io
+    services:
+      live:
+        stages:
+          - deployment: live
+            weight: 100
+        hosts:
+          - aws-credentials-broker
+          - aws-credentials-broker.us-east-2.flow.io
+        gateways:
+          - mesh
+          - aws-credentials-broker-flow-io


### PR DESCRIPTION
Lets us-east-2 broker pods serve users on `aws-credentials-broker.us-east-2.flow.io` when us-east-1 is unhealthy. Companion to [flowcommerce/eks-cluster#2659](https://github.com/flowcommerce/eks-cluster/pull/2659) (new `*.flow.io` ALB and istio gateway in us-east-2) and the matching `aws-terraform` change (Cloudflare CNAMEs).

## Changes

`deploy/aws-credentials-broker/app.yaml`
- Add `region` Helm parameter (`Jenkins_will_update_the_region`) so `argoActionsv2.groovy` fills in the per-region value at deploy time.

`deploy/aws-credentials-broker/values.yaml`
- Region-specific config (`ingress`, `services`, `deployment.<stage>.env`) lives **only** under `regions.<region>` — no top-level defaults, no fallbacks. Both `regions.us-east-1` and `regions.us-east-2` carry full blocks.
- Non-region-specific fields (`resources`, `nodeSelector`, `deployments.live.minReplicas`, `serviceAccountName`, etc.) stay at the top level.

`deploy/aws-credentials-broker/templates/deployment.yaml`
- Resolve `$regionDeployment` from `regions[<region>].deployment[<stage>]` via `dig`, wrapped in `required` so a missing region produces a clear error instead of silently falling back.
- Append the regional env list at the end of the env block. The Secret-backed env entries (`COOKIE_SECRET_*`, `HOSTED_DOMAIN`, `GOOGLE_CLIENT_*`, `GOOGLE_ADMIN_EMAIL`, `GOOGLE_SA_*`, kubernetes pod metadata, Datadog) stay hardcoded — they reference Kubernetes Secrets and aren't region-specific.

`deploy/aws-credentials-broker/templates/{ingress,istio}.yaml`
- Same `dig` + `required` pattern: pull `regions[<region>].ingress` and `regions[<region>].services` from the resolved region. Missing region → error.

The Secret in `eks-cluster` still carries `allowed_origin` and `google_client_redirect` for backwards compat with pods deployed under the previous chart version. A follow-up PR can drop those keys from the Secret once this chart is verified live in both regions.

## Roll-out

1. `eks-cluster#2659` already merged; new ALB `k8s-istiosys-flowioin-6b674c630c-...` and `istio-alb-ingressgateway-flow-io` pods running in us-east-2.
2. `aws-terraform` applied; Cloudflare CNAMEs `alb-prod.us-east-2.flow.io` and `aws-credentials-broker.us-east-2.flow.io` are live.
3. **Before merging this PR** (or shortly after): add `https://aws-credentials-broker.us-east-2.flow.io/oauth/google/callback` as an Authorized redirect URI and `https://aws-credentials-broker.us-east-2.flow.io` as an Authorized JavaScript origin on the broker's Google OAuth client. If forgotten, the deploy still works (healthcheck returns 200) — only end-to-end Google login will fail with `redirect_uri_mismatch`.
4. Merge this PR; Jenkins runs `argoActionsMultiregion` which fans out per region. us-east-1 render is unchanged. us-east-2 deploys the new Gateway and the regional env vars.

## Test plan

- [ ] Jenkins main build green for both `us-east-1` and `us-east-2` parallel stages.
- [ ] `curl https://aws-credentials-broker.flow.io/_internal_/healthcheck` → 200 (us-east-1 unaffected).
- [ ] `curl https://aws-credentials-broker.us-east-2.flow.io/_internal_/healthcheck` → 200.
- [ ] End-to-end Google OAuth login through the regional URL.

## Notes

- `skipDiff: true` is set in the Jenkinsfile because `argoActionsv2.groovy`'s diff path expects a `generic-charts.git` source to extract the chart version, and we use a local chart. A separate lib-jenkins-pipeline change to handle local-chart sources was prototyped and discarded — the diff display had artifacts (SSA-merged `value:`/`valueFrom:`, region placeholder not substituted) that made it untrustworthy for this PR.