### PR TITLE
FDN-4803: Make /roles + role-hint flow tolerate stale sessions

### DIFF
--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"log/slog"
@@ -45,8 +46,81 @@ const (
 	callbackKey  = "_awscb_call"
 	roleHintKey  = "_awscb_role"
 	listRolesKey = "_awscb_list"
+	expiryKey    = "_awscb_exp"
 	stateError   = "Unexpected state. Secure session cookies are missing... Please try again."
 )
+
+// preAuthMaxAge bounds the pre-OAuth state cookie. Just needs to outlast
+// the user redirecting to Google and back — much shorter than the gorilla
+// CookieStore default of 30 days, which would otherwise leak via Save().
+const preAuthMaxAge = 600
+
+// expiryBuffer is how much earlier than the access token's actual expiry
+// we let the cookie die, so a still-living cookie always implies a
+// still-living token.
+const expiryBuffer = 300
+
+// pinCookieToTokenLifetime sets cookie Options so MaxAge tracks the
+// access token's remaining lifetime (minus expiryBuffer). Returns false
+// if the session has no recorded expiry or the token is already within
+// the buffer window — caller should reauth in that case.
+//
+// Without this, sesh.Save() picks up the gorilla CookieStore default of
+// 30 days, so the browser cookie outlives the access token and the next
+// CLI login redirects to /roles with a dead token (HTTP 500).
+func pinCookieToTokenLifetime(sesh sessions.Session, secure bool) bool {
+	raw := sesh.Get(expiryKey)
+	if raw == nil {
+		return false
+	}
+	var unix int64
+	switch v := raw.(type) {
+	case int64:
+		unix = v
+	case int:
+		unix = int64(v)
+	case float64:
+		unix = int64(v)
+	default:
+		return false
+	}
+	remaining := unix - time.Now().Unix() - expiryBuffer
+	if remaining <= 0 {
+		return false
+	}
+	sesh.Options(sessions.Options{
+		MaxAge:   int(remaining),
+		HttpOnly: true,
+		Secure:   secure,
+		Path:     "/",
+	})
+	return true
+}
+
+// reauth clears the access/id tokens but keeps the CLI handoff hints
+// (callbackKey, roleHintKey, listRolesKey) so the post-OAuth /roles
+// flow can still find them, and starts a fresh OAuth round trip.
+func reauth(c *gin.Context, conf *oauth2.Config, secure bool) {
+	sesh := sessions.Default(c)
+	sesh.Delete(sessionKey)
+	sesh.Delete(idKey)
+	sesh.Delete(expiryKey)
+
+	state := base64.StdEncoding.EncodeToString(utils.RandToken(32))
+	sesh.Set(stateKey, state)
+	sesh.Options(sessions.Options{
+		MaxAge:   preAuthMaxAge,
+		HttpOnly: true,
+		Secure:   secure,
+		Path:     "/",
+	})
+	if err := sesh.Save(); err != nil {
+		slog.Error("Failed to save session", "error", err)
+		c.AbortWithStatus(http.StatusInternalServerError)
+		return
+	}
+	c.Redirect(http.StatusTemporaryRedirect, conf.AuthCodeURL(state))
+}
 
 func callback(conf *oauth2.Config, secure bool) gin.HandlerFunc {
 	return func(c *gin.Context) {
@@ -86,8 +160,9 @@ func callback(conf *oauth2.Config, secure bool) gin.HandlerFunc {
 		sesh := sessions.Default(c)
 		sesh.Set(idKey, idTok)
 		sesh.Set(sessionKey, tok.AccessToken)
+		sesh.Set(expiryKey, tok.Expiry.Unix())
 		sesh.Options(sessions.Options{
-			MaxAge:   int(expiresIn.Seconds()) - 300, // Expire 5 minutes before the access token expires
+			MaxAge:   int(expiresIn.Seconds()) - expiryBuffer,
 			HttpOnly: true,
 			Secure:   secure,
 			Path:     "/",
@@ -103,7 +178,7 @@ func callback(conf *oauth2.Config, secure bool) gin.HandlerFunc {
 	}
 }
 
-func listRoles(conf *oauth2.Config, ngin *gin.Engine, adminConf *utils.AdminUserConfig) gin.HandlerFunc {
+func listRoles(conf *oauth2.Config, ngin *gin.Engine, adminConf *utils.AdminUserConfig, secure bool) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		sesh := sessions.Default(c)
 		accessToken := sesh.Get(sessionKey)
@@ -114,6 +189,11 @@ func listRoles(conf *oauth2.Config, ngin *gin.Engine, adminConf *utils.AdminUser
 
 		user, err := utils.GetUserRoles(accessToken.(string), conf, adminConf)
 		if err != nil {
+			if errors.Is(err, utils.ErrInvalidToken) {
+				slog.Info("Access token rejected by Google; restarting OAuth", "error", err)
+				reauth(c, conf, secure)
+				return
+			}
 			slog.Error("Failed to get user roles", "error", err)
 			c.AbortWithStatus(http.StatusInternalServerError)
 			return
@@ -235,7 +315,7 @@ func success(c *gin.Context) {
 	})
 }
 
-func login(conf *oauth2.Config, adminConf *utils.AdminUserConfig) gin.HandlerFunc {
+func login(conf *oauth2.Config, adminConf *utils.AdminUserConfig, secure bool) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		requestedRoleArn := c.PostForm("role")
 
@@ -249,6 +329,11 @@ func login(conf *oauth2.Config, adminConf *utils.AdminUserConfig) gin.HandlerFun
 
 		user, err := utils.GetUserRoles(accessToken.(string), conf, adminConf)
 		if err != nil {
+			if errors.Is(err, utils.ErrInvalidToken) {
+				slog.Info("Access token rejected by Google; restarting OAuth", "error", err)
+				reauth(c, conf, secure)
+				return
+			}
 			slog.Error("Failed to get user roles", "error", err)
 			c.AbortWithStatus(http.StatusInternalServerError)
 			return
@@ -387,8 +472,8 @@ func main() {
 	r.LoadHTMLGlob("templates/*.tmpl")
 
 	r.GET("/oauth/google/callback", callback(conf, secure))
-	r.GET("/roles", listRoles(conf, r, adminConf))
-	r.POST("/login", login(conf, adminConf))
+	r.GET("/roles", listRoles(conf, r, adminConf, secure))
+	r.POST("/login", login(conf, adminConf, secure))
 	r.GET("/success", success)
 	r.GET("/", func(c *gin.Context) {
 		sesh := sessions.Default(c)
@@ -422,7 +507,12 @@ func main() {
 
 			state := base64.StdEncoding.EncodeToString(utils.RandToken(32))
 			sesh.Set(stateKey, state)
-			sesh.Options(sessions.Options{HttpOnly: true, Path: "/"})
+			sesh.Options(sessions.Options{
+				MaxAge:   preAuthMaxAge,
+				HttpOnly: true,
+				Secure:   secure,
+				Path:     "/",
+			})
 			if err := sesh.Save(); err != nil {
 				slog.Error("Failed to save session", "error", err)
 				c.AbortWithStatus(http.StatusInternalServerError)
@@ -430,6 +520,17 @@ func main() {
 			}
 
 			c.Redirect(http.StatusTemporaryRedirect, conf.AuthCodeURL(state))
+			return
+		}
+
+		// We have a session token, but the cookie's MaxAge defaults to
+		// 30 days unless we override it on every Save. If we can't pin
+		// the cookie to the access token's known remaining lifetime
+		// (either no expiry recorded, or already past), treat the
+		// session as dead and restart OAuth — the alternative is
+		// redirecting to /roles with a stale token and 500'ing.
+		if !pinCookieToTokenLifetime(sesh, secure) {
+			reauth(c, conf, secure)
 			return
 		}
 

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -3,7 +3,10 @@ package utils
 import (
 	"crypto/rand"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"io/ioutil"
+	"net/http"
 	"os"
 	"strconv"
 
@@ -12,6 +15,11 @@ import (
 	"golang.org/x/oauth2/jwt"
 	admin "google.golang.org/api/admin/directory/v1"
 )
+
+// ErrInvalidToken signals that the OAuth access token in the session was
+// rejected by Google (typically because it expired). Callers should treat
+// this as "session is dead, restart OAuth" rather than a generic 500.
+var ErrInvalidToken = errors.New("oauth access token rejected by google")
 
 
 // FlexInt is from: https://engineering.bitnami.com/articles/dealing-with-json-with-non-homogeneous-types-in-go.html
@@ -119,9 +127,22 @@ func GetUserRoles(accessToken string, conf *oauth2.Config, config *AdminUserConf
 	defer email.Body.Close()
 	data, _ := ioutil.ReadAll(email.Body)
 
+	// Google returns 401 for an expired/revoked access token. Without this
+	// check, we'd unmarshal the error body into an empty User and then call
+	// the Admin SDK with userKey="", which surfaces as a confusing 400.
+	if email.StatusCode == http.StatusUnauthorized {
+		return nil, ErrInvalidToken
+	}
+	if email.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("userinfo: HTTP %d: %s", email.StatusCode, string(data))
+	}
+
 	var usr User
 	if err = json.Unmarshal(data, &usr); err != nil {
 		return nil, err
+	}
+	if usr.Email == "" {
+		return nil, ErrInvalidToken
 	}
 
 	rls, err := getGoogleAdminUserRoles(usr.Email, config)


### PR DESCRIPTION
## Summary

Three commits on top of the merged PR #68 (default-role hint + list-roles mode), to make the new flow robust to repeat / stale-cookie scenarios.

- **Capture role hint and list-roles on every visit to `/`** — the original PR #68 only set `_awscb_role` / `_awscb_list` on the first visit (the `tok == nil` branch). Repeat logins with an existing session would silently drop the new flags and the CLI's `--role` / `--list-roles` would have no effect.
- **Clear one-shot session keys after CLI handoff** — once `/login` (or list-mode `/roles`) hands credentials/role list back to the CLI, delete `callbackKey` / `roleHintKey` / `listRolesKey` so a later bare `/roles` visit in the browser doesn't auto-apply yesterday's hint or terminate into an empty list-mode redirect.
- **Pin cookie MaxAge to token expiry, self-heal on stale token** — fixes the HTTP 500 (`googleapi: Error 400: Bad Request`) that surfaced on `dev login` ~hours after a successful login. Two underlying issues:
  - The new `/` handler calls `sesh.Save()` on every visit. Without an explicit `sesh.Options(...)` first, gin-contrib/sessions writes the cookie with the gorilla CookieStore default `MaxAge: 86400 * 30`, so the cookie keeps a 30-day life while the Google access token still dies in ~1 hour. Next login finds `tok != nil`, redirects to `/roles`, and Google rejects the dead token. Fix: persist `tok.Expiry.Unix()` under a new `_awscb_exp` key in `callback()`, and pin `MaxAge = expiry - now - 5min` on every Save in `/`.
  - `utils.GetUserRoles` ignored the userinfo HTTP status, so a 401 there got unmarshaled into an empty `User`, then handed to the Admin SDK as `userKey=""`, surfacing as the confusing 400. Fix: return new `utils.ErrInvalidToken` on 401 / empty email; `listRoles` and `login` catch it and call `reauth(...)`, which clears auth keys but preserves the CLI handoff hints and starts a fresh OAuth round-trip.

Sessions written before this change have no `_awscb_exp`, so the first visit after deploy falls into the same reauth path (one extra OAuth round-trip, then healthy). No manual cookie clearing required.

Companion change on the CLI side: flowcommerce/tools `fdn-4803-default-role` (default `--role Developer`, new `--list-roles` mode).

## Test plan

- [ ] Fresh login (no broker cookie) — `dev login` writes credentials, `dev login --role <name>` assumes the requested role, `dev login --list-roles` prints the role list and exits cleanly.
- [ ] Repeat `dev login` within token lifetime (~1 hour) — no extra OAuth round-trip, behaves like a fresh login.
- [ ] Repeat `dev login` ~2+ hours after the previous login (or with the previous broker cookie still in the browser) — observe one transparent OAuth round-trip, then credentials written. No HTTP 500, no manual cookie clearing.
- [ ] Browser visit to `https://aws-credentials-broker.flow.io/roles` after a `dev login --role X` flow — does not auto-redirect to `/login` with a stale role hint; either shows the picker or, if the session expired, redirects to `/`.
- [ ] Verify `_awscb_exp` cookie value is set after `/oauth/google/callback`, and the session cookie's `Max-Age` (DevTools → Application → Cookies) is in the ~3300s range, not 30 days.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Session cookies now track token lifetimes so cookie expiry matches actual OAuth token expiry, avoiding stale sessions and unwanted redirects.
  * The app auto-reauthenticates when tokens are invalid and more reliably detects rejected OAuth tokens.
  * Session flow hints are consumed per-use and sessions are saved explicitly before rendering or redirects to prevent leaking state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->